### PR TITLE
Added option to input multiple addresses

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,8 +5,10 @@ This is a simple python script to get the battery charge level of some bluetooth
 # How to run
 ```bash
 chmod +x bl_battery.py
-./bl_battery.py [HEADSET_MAC_ADDRESS]
+./bl_battery.py [ADDRESSES] 
 ```
+You can input addresses for as many headphones and devices as you want seperated by spaces.
+
 ### Polybar
 If you are interested in using this in polybar, Try [this project](https://github.com/keystroke3/Bluetooth_Headset_Battery_Level) that has a nice look and icons with setup instructions.
 

--- a/bl_battery.py
+++ b/bl_battery.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python3
 
-#
-# This script prints the battery charge level of some bluetooth headsets
-# 
+"""
+This script prints the battery charge level of some bluetooth headsets
+"""
 
 # License: GPL-3.0
 # Author: @TheWeirdDev
 # 29 Sept 2019
 
-import socket, sys
+import socket
+import sys
+
 
 def send(sock, message):
     sock.send(b"\r\n" + message + b"\r\n")
 
-def getATCommand(sock, line):
+
+def getATCommand(sock, line, device):
     if b"BRSF" in line:
         send(sock, b"+BRSF:20")
         send(sock, b"OK")
@@ -24,39 +27,42 @@ def getATCommand(sock, line):
         send(sock, b"+CIND: 5")
         send(sock, b"OK")
     elif b"IPHONEACCEV" in line:
-        if not b',' in line:
+        if b',' not in line:
             return True
-        
-        parts = line[line.index(b',') + 1 : -1].split(b',')
+
+        parts = line[line.index(b',') + 1: -1].split(b',')
         if len(parts) < 1 or (len(parts) % 2) != 0:
             return True
-        
         i = 0
         while i < len(parts):
             key = int(parts[i])
             val = int(parts[i + 1])
-            
             if key == 1:
                 blevel = (val + 1) * 10
-                print("Battery level: {}%\n".format(blevel))
+                print(f"Battery level for {device} is {blevel}%")
                 return False
             i += 2
     else:
         send(sock, b"OK")
     return True
 
+
 def main():
     if (len(sys.argv) < 2):
         print("Usage: bl_battery.py <BT_MAC_ADDRESS>")
         exit()
-    
-    BT_ADDRESS = sys.argv[1]
-    
-    s = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_STREAM, socket.BTPROTO_RFCOMM)
-    s.connect((BT_ADDRESS, 4))
+    else:
+        for device in sys.argv[1:]:
+            try:
+                s = socket.socket(socket.AF_BLUETOOTH,
+                                  socket.SOCK_STREAM, socket.BTPROTO_RFCOMM)
+                s.connect((device, 4))
 
-    while getATCommand(s, s.recv(128)):
-        pass
-             
+                while getATCommand(s, s.recv(128), device):
+                    pass
+            except OSError:
+                print(f"{device} is offline")
+
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
I have noticed that if you have multiple bluetooth devices connected, you may have to run this command multiple times for all devices. This adds the option to simply add as many addresses as you wish and it goes through all and checks them. If you disagree with this, I understand.