### PR TITLE
Select a port or try ports 1..9

### DIFF
--- a/bl_battery.py
+++ b/bl_battery.py
@@ -70,22 +70,15 @@ def main():
         for device in sys.argv[1:]:
             i = device.find('.')
             if i == -1:
-                ports = range(1, 10)
+                port = 4
             else:
-                ports = [int(device[i+1:])]
+                port = int(device[i+1:])
                 device = device[:i]
             try:
-                for p in ports:
-                    try:
-                        s = socket.socket(socket.AF_BLUETOOTH,
-                                          socket.SOCK_STREAM,
-                                          socket.BTPROTO_RFCOMM)
-                        s.connect((device, p))
-                        break
-                    except OSError as e:
-                        if e.errno != errno.EHOSTDOWN or p == ports[-1]:
-                            raise
-                while getATCommand(s, s.recv(128), device, p):
+                s = socket.socket(socket.AF_BLUETOOTH,
+                                  socket.SOCK_STREAM, socket.BTPROTO_RFCOMM)
+                s.connect((device, port))
+                while getATCommand(s, s.recv(128), device, port):
                     pass
             except OSError as e:
                 print(f"{device} is offline", e)


### PR DESCRIPTION
Optionally specify a port number (using syntax `MAC.PORT`) or try ports 1–9 if no port number is specified. This change is intended for devices that use other port than 4 used in the original script.