### PR TITLE
Add instructions on how to find bluetooth MACs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -80,7 +80,7 @@ Device E8:AB:FA:XX:XX:XX (public)
 ```
 So you can use
 ```
-bluetooth_battery.py $(bluetoothctl info | awk '/^Device/ {print $2}')
+bluetooth_battery.py $(bluetoothctl devices | awk '/^Device/ {print $2}')
 ```
 to query the battery of all connected devices.
 

--- a/Readme.md
+++ b/Readme.md
@@ -65,16 +65,16 @@ docker run --rm -ti --privileged --net=host bluetooth_battery_level "BT_MAC_ADDR
 There are a variety of utilities that can find the MAC address of your bluetooth device.  Here is one, this command is in the `bluez` package, and the given argument gets a list of all devices it knows about, even if not currently available.
 ```
 $ bluetoothctl devices
-Device E8:AB:FA:27:9E:DE iTeknic IK-BH002
-Device D0:77:14:3A:2C:24 Barak's Moto X4
-Device E8:AB:FA:27:9F:49 iTeknic IK-BH002
+Device E8:AB:FA:XX:XX:XX iTeknic IK-BH002
+Device D0:77:14:XX:XX:XX Barak's Moto X4
+Device E8:AB:FA:XX:XX:XX iTeknic IK-BH002
 ```
 The 1st and 3rd would be relevant here, as those are headsets. But if you try to get the battery level of a device that's not currently connected, there is a very long pause until the query times out.
 
 This shows devices that are actually connected.
 ```
 $ bluetoothctl info
-Device E8:AB:FA:27:9E:DE (public)
+Device E8:AB:FA:XX:XX:XX (public)
 	Name: iTeknic IK-BH002
 	...
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ sudo apt install libbluetooth-dev python3-dev
 If you are using OpenSUSE, you will need to install these packages:
 ```bash
 bluez
-bluez-devel 
+bluez-devel
 python3-devel
 python3-pybluez
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,7 @@ You can open a new issue for discussion or check the existing ones for more info
 ## Tested on
 
 - [x] Linux (ArchLinux 5.6.14)
+- [x] Debian GNU/Linux (bullseye 5.9)
 
 # 💸 Donate
 

--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,29 @@ _make sure you have `python-pybluez` or `python3-pybluez` or `python3-bluez` ins
 
 **You can input addresses for as many devices as you want separated by space.**
 
+### Finding MAC address
 
+There are a variety of utilities that can find the MAC address of your bluetooth device.  Here is one, this command is in the `bluez` package, and the given argument gets a list of all devices it knows about, even if not currently available.
+```
+$ bluetoothctl devices
+Device E8:AB:FA:27:9E:DE iTeknic IK-BH002
+Device D0:77:14:3A:2C:24 Barak's Moto X4
+Device E8:AB:FA:27:9F:49 iTeknic IK-BH002
+```
+The 1st and 3rd would be relevant here, as those are headsets. But if you try to get the battery level of a device that's not currently connected, there is a very long pause until the query times out.
+
+This shows devices that are actually connected.
+```
+$ bluetoothctl info
+Device E8:AB:FA:27:9E:DE (public)
+	Name: iTeknic IK-BH002
+	...
+```
+So you can use
+```
+bluetooth_battery.py $(bluetoothctl info | awk '/^Device/ {print $2}')
+```
+to query the battery of all connected devices.
 
 ### It didn't work?
 

--- a/Readme.md
+++ b/Readme.md
@@ -69,7 +69,7 @@ Device E8:AB:FA:XX:XX:XX iTeknic IK-BH002
 Device D0:77:14:XX:XX:XX Barak's Moto X4
 Device E8:AB:FA:XX:XX:XX iTeknic IK-BH002
 ```
-The 1st and 3rd would be relevant here, as those are headsets. But if you try to get the battery level of a device that's not currently connected, there is a very long pause until the query times out.
+The 1st and 3rd would be relevant here, as those are headsets.
 
 This shows devices that are actually connected.
 ```


### PR DESCRIPTION
I really like these instructions and i think this information should be included in the main repo