### PR TITLE
Support Bose's proprietary battery protocol.

### DIFF
--- a/bluetooth_battery.py
+++ b/bluetooth_battery.py
@@ -44,7 +44,7 @@ def get_at_command(sock, line, device):
         send(sock, b"+BIND: 2,1")
         send(sock, b"OK")
     elif b"XAPL=" in line:
-        send(sock, b"+XAPL: iPhone,7")
+        send(sock, b"+XAPL=iPhone,7")
         send(sock, b"OK")
     elif b"IPHONEACCEV" in line:
         parts = line.strip().split(b',')[1:]


### PR DESCRIPTION
Bose's headphones (at least my QC 35 II) don't seem to give battery data
to any of the regular AT commands; it responds to the commands given just fine,
but never gives out battery data. Thus, bluetooth_battery.py just hangs
instead of finding the battery percentage.

However, Bose Connect has its own proprietary (non-AT-based) protocol,
which based-connect has reverse-engineered. If we detect a Bose MAC address
and the user hasn't overridden the port, connect to port 8 and speak that
protocol. It supports percentage precision (just sends a number 0-100 raw
over the protocol), but in practice, always seems to round off to the
nearest 10%.