### PR TITLE
Include openSUSE Leap 15.3 to 'Tested on' section

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -109,6 +109,7 @@ You can open a new issue for discussion or check the existing ones for more info
 - [x] NixOS 20.09 (20.09.2386.ae1b121d9a6)
 - [x] Debian GNU/Linux (bullseye 5.9)
 - [x] Ubuntu/Linux (Focal Fossa 20.04.1)
+- [x] openSUSE (Leap 15.3)
 
 # 🤝 Thanks
 


### PR DESCRIPTION
Hi, I've confirmed it works well with my headset (Bose QuietComfort 35 wireless headphones II) on openSUSE 15.3.  
https://www.bose.com/en_us/products/headphones/over_ear_headphones/quietcomfort-35-wireless-ii.html

![image](https://user-images.githubusercontent.com/265721/138784861-6a2c3a61-36f9-4622-ae2d-71bdb38847c8.png)

Thank you for nice tool.