### PR TITLE
fixed "error in PyBluez setup command: use_2to3 is invalid." during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:3.9-slim-bullseye as builder
 RUN apt update && apt install -y build-essential bluetooth libbluetooth-dev
 WORKDIR /app
-RUN pip3 install setuptools==v57.5.0 && \
+RUN pip3 install setuptools==v58.0.0 && \
     pip3 wheel --no-cache-dir --no-deps --wheel-dir /app/wheel/ pybluez
 
 ### Final

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 FROM python:3.9-slim-bullseye as builder
 RUN apt update && apt install -y build-essential bluetooth libbluetooth-dev
 WORKDIR /app
-RUN pip3 wheel --no-cache-dir --no-deps --wheel-dir /app/wheel/ pybluez
+RUN pip3 install setuptools==v57.5.0 && \
+    pip3 wheel --no-cache-dir --no-deps --wheel-dir /app/wheel/ pybluez
 
 ### Final
 FROM python:3.9-slim-bullseye


### PR DESCRIPTION
docker build . breaks with:

~~~
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in PyBluez setup command: use_2to3 is invalid.
      [end of output]
~~~

Found: https://stackoverflow.com/questions/69100275/error-while-downloading-the-requirements-using-pip-install-setup-command-use-2

Fixed by adding fixed setuptools version (`pip3 install setuptools==v57.5.0`).


