### PR TITLE
AUR package may need manual install of pybluez

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -87,6 +87,9 @@ You can install this library using
 yay -S python-bluetooth-battery
 ```
 
+_the dependency `pybluez` should be installed automatically, but if not, you may need to install it manually_  
+This can be done with `pip3 install git+https://github.com/pybluez/pybluez@master`.
+
 --------
 
 ## Library usage


### PR DESCRIPTION
The AUR package didn't automatically install `pybluez`. After following #78, I was able to get it working. There should be a note that the AUR package may need a manual install.