### PR TITLE
improved AT+XEVENT battery parsing

### DIFF
--- a/bluetooth_battery.py
+++ b/bluetooth_battery.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-
 """
 A python library to get battery level from Bluetooth headsets
 """
-
 # License: GPL-3.0
 # Author: @TheWeirdDev, @GaLaXy102
 # 29 Sept 2019
-
 import argparse
-from typing import Dict, List, Optional, Union
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
 
 import bluetooth
 

--- a/bluetooth_battery.py
+++ b/bluetooth_battery.py
@@ -137,7 +137,12 @@ class BatteryStateQuerier:
                     break
             elif b"XEVENT=BATTERY" in line:
                 params = line.strip().split(b"=")[1].split(b",")
-                result = int(params[1]) / int(params[2]) * 100
+                if len(params) >= 3:
+                    # AT+XEVENT=BATTERY,6,11,461,0
+                    result = int(params[1]) / int(params[2]) * 100
+                else:
+                    # AT+XEVENT=BATTERY,9
+                    result = (int(params[1]) + 1) * 10
                 break
             else:
                 sock.send(b"OK")

--- a/bluetooth_battery.py
+++ b/bluetooth_battery.py
@@ -9,8 +9,9 @@ A python library to get battery level from Bluetooth headsets
 # 29 Sept 2019
 
 import argparse
+from typing import Dict, List, Optional, Union
+
 import bluetooth
-from typing import Optional, Union, List, Dict
 
 
 class BatteryQueryError(bluetooth.BluetoothError):

--- a/bluetooth_battery.py
+++ b/bluetooth_battery.py
@@ -51,13 +51,15 @@ class RFCOMMSocket(bluetooth.BluetoothSocket):
         Find the RFCOMM port number for a given bluetooth device
         """
         uuid = "0000111e-0000-1000-8000-00805f9b34fb"
-        services: List[Dict] = bluetooth.find_service(address=device_mac, uuid=uuid)
+        services: List[Dict] = bluetooth.find_service(
+            address=device_mac, uuid=uuid)
 
         for service in services:
             if "protocol" in service.keys() and service["protocol"] == "RFCOMM":
                 return service["port"]
         # Raise Interface error when the required service is not offered my the end device
-        raise bluetooth.BluetoothError("Couldn't find the RFCOMM port number. Perhaps the device is offline?")
+        raise bluetooth.BluetoothError(
+            "Couldn't find the RFCOMM port number. Perhaps the device is offline?")
 
     def send(self, data):
         """
@@ -78,7 +80,8 @@ class BatteryStateQuerier:
 
         The actual query can be performed using the int() and str() method.
         """
-        self._bt_settings = bluetooth_mac, int(bluetooth_port or RFCOMMSocket.find_rfcomm_port(bluetooth_mac))
+        self._bt_settings = bluetooth_mac, int(
+            bluetooth_port or RFCOMMSocket.find_rfcomm_port(bluetooth_mac))
 
     def __int__(self):
         """
@@ -105,7 +108,8 @@ class BatteryStateQuerier:
                 sock.send(b"+BRSF: 1024")
                 sock.send(b"OK")
             elif b"CIND=" in line:
-                sock.send(b"+CIND:(\"service\",(0-1)),(\"call\",(0-1)),(\"callsetup\",(0-3)),(\"callheld\",(0-2)),(\"battchg\",(0-5))")
+                sock.send(
+                    b"+CIND:(\"service\",(0-1)),(\"call\",(0-1)),(\"callsetup\",(0-3)),(\"callheld\",(0-2)),(\"battchg\",(0-5))")
                 sock.send(b"OK")
             elif b"CIND?" in line:
                 sock.send(b"+CIND: 0,0,0,0,3")
@@ -159,13 +163,15 @@ def main():
     list a bluetooth socket will be opened and the battery level will be read
     and printed to stdout
     """
-    parser = argparse.ArgumentParser(description="Get battery level from Bluetooth headsets")
+    parser = argparse.ArgumentParser(
+        description="Get battery level from Bluetooth headsets")
     parser.add_argument("devices", metavar="DEVICE_MAC[.PORT]", type=str, nargs="+",
                         help="(MAC address of target)[.SPP Port]")
     args = parser.parse_args()
     for device in args.devices:
         query = BatteryStateQuerier(*device.split("."))
         print("Battery level for {} is {}".format(device, str(query)))
+
 
 if __name__ == "__main__":
     main()

--- a/bluetooth_battery.py
+++ b/bluetooth_battery.py
@@ -19,6 +19,7 @@ class BatteryQueryError(bluetooth.BluetoothError):
 
 
 class SocketDataIterator:
+
     def __init__(self, sock: bluetooth.BluetoothSocket, chunk_size: int = 128):
         """
         Create an Iterator over the given Socket
@@ -36,6 +37,7 @@ class SocketDataIterator:
 
 
 class RFCOMMSocket(bluetooth.BluetoothSocket):
+
     def __init__(self, proto=bluetooth.RFCOMM, _sock=None):
         super().__init__(proto, _sock)
 
@@ -51,10 +53,12 @@ class RFCOMMSocket(bluetooth.BluetoothSocket):
         Find the RFCOMM port number for a given bluetooth device
         """
         uuid = "0000111e-0000-1000-8000-00805f9b34fb"
-        services: List[Dict] = bluetooth.find_service(address=device_mac, uuid=uuid)
+        services: List[Dict] = bluetooth.find_service(address=device_mac,
+                                                      uuid=uuid)
 
         for service in services:
-            if "protocol" in service.keys() and service["protocol"] == "RFCOMM":
+            if "protocol" in service.keys(
+            ) and service["protocol"] == "RFCOMM":
                 return service["port"]
         # Raise Interface error when the required service is not offered my the end device
         raise bluetooth.BluetoothError(
@@ -69,9 +73,10 @@ class RFCOMMSocket(bluetooth.BluetoothSocket):
 
 
 class BatteryStateQuerier:
-    def __init__(
-        self, bluetooth_mac: str, bluetooth_port: Optional[Union[str, int]] = None
-    ):
+
+    def __init__(self,
+                 bluetooth_mac: str,
+                 bluetooth_port: Optional[Union[str, int]] = None):
         """
         Prepare a query for the end devices' battery state
 
@@ -82,8 +87,7 @@ class BatteryStateQuerier:
         The actual query can be performed using the int() and str() method.
         """
         self._bt_settings = bluetooth_mac, int(
-            bluetooth_port or RFCOMMSocket.find_rfcomm_port(bluetooth_mac)
-        )
+            bluetooth_port or RFCOMMSocket.find_rfcomm_port(bluetooth_mac))
 
     def __int__(self):
         """
@@ -167,8 +171,7 @@ def main():
     and printed to stdout
     """
     parser = argparse.ArgumentParser(
-        description="Get battery level from Bluetooth headsets"
-    )
+        description="Get battery level from Bluetooth headsets")
     parser.add_argument(
         "devices",
         metavar="DEVICE_MAC[.PORT]",

--- a/bluetooth_battery.py
+++ b/bluetooth_battery.py
@@ -35,7 +35,6 @@ class SocketDataIterator:
 
 
 class RFCOMMSocket(bluetooth.BluetoothSocket):
-
     def __init__(self, proto=bluetooth.RFCOMM, _sock=None):
         super().__init__(proto, _sock)
 
@@ -51,15 +50,15 @@ class RFCOMMSocket(bluetooth.BluetoothSocket):
         Find the RFCOMM port number for a given bluetooth device
         """
         uuid = "0000111e-0000-1000-8000-00805f9b34fb"
-        services: List[Dict] = bluetooth.find_service(
-            address=device_mac, uuid=uuid)
+        services: List[Dict] = bluetooth.find_service(address=device_mac, uuid=uuid)
 
         for service in services:
             if "protocol" in service.keys() and service["protocol"] == "RFCOMM":
                 return service["port"]
         # Raise Interface error when the required service is not offered my the end device
         raise bluetooth.BluetoothError(
-            "Couldn't find the RFCOMM port number. Perhaps the device is offline?")
+            "Couldn't find the RFCOMM port number. Perhaps the device is offline?"
+        )
 
     def send(self, data):
         """
@@ -69,8 +68,9 @@ class RFCOMMSocket(bluetooth.BluetoothSocket):
 
 
 class BatteryStateQuerier:
-
-    def __init__(self, bluetooth_mac: str, bluetooth_port: Optional[Union[str, int]] = None):
+    def __init__(
+        self, bluetooth_mac: str, bluetooth_port: Optional[Union[str, int]] = None
+    ):
         """
         Prepare a query for the end devices' battery state
 
@@ -81,7 +81,8 @@ class BatteryStateQuerier:
         The actual query can be performed using the int() and str() method.
         """
         self._bt_settings = bluetooth_mac, int(
-            bluetooth_port or RFCOMMSocket.find_rfcomm_port(bluetooth_mac))
+            bluetooth_port or RFCOMMSocket.find_rfcomm_port(bluetooth_mac)
+        )
 
     def __int__(self):
         """
@@ -109,7 +110,8 @@ class BatteryStateQuerier:
                 sock.send(b"OK")
             elif b"CIND=" in line:
                 sock.send(
-                    b"+CIND:(\"service\",(0-1)),(\"call\",(0-1)),(\"callsetup\",(0-3)),(\"callheld\",(0-2)),(\"battchg\",(0-5))")
+                    b'+CIND:("service",(0-1)),("call",(0-1)),("callsetup",(0-3)),("callheld",(0-2)),("battchg",(0-5))'
+                )
                 sock.send(b"OK")
             elif b"CIND?" in line:
                 sock.send(b"+CIND: 0,0,0,0,3")
@@ -127,12 +129,12 @@ class BatteryStateQuerier:
                 sock.send(b"+XAPL=iPhone,7")
                 sock.send(b"OK")
             elif b"IPHONEACCEV" in line:
-                parts = line.strip().split(b',')[1:]
+                parts = line.strip().split(b",")[1:]
                 if len(parts) > 1 and (len(parts) % 2) == 0:
                     parts = iter(parts)
                     params = dict(zip(parts, parts))
-                    if b'1' in params:
-                        result = (int(params[b'1']) + 1) * 10
+                    if b"1" in params:
+                        result = (int(params[b"1"]) + 1) * 10
                         break
             elif b"BIEV=" in line:
                 params = line.strip().split(b"=")[1].split(b",")
@@ -164,9 +166,15 @@ def main():
     and printed to stdout
     """
     parser = argparse.ArgumentParser(
-        description="Get battery level from Bluetooth headsets")
-    parser.add_argument("devices", metavar="DEVICE_MAC[.PORT]", type=str, nargs="+",
-                        help="(MAC address of target)[.SPP Port]")
+        description="Get battery level from Bluetooth headsets"
+    )
+    parser.add_argument(
+        "devices",
+        metavar="DEVICE_MAC[.PORT]",
+        type=str,
+        nargs="+",
+        help="(MAC address of target)[.SPP Port]",
+    )
     args = parser.parse_args()
     for device in args.devices:
         query = BatteryStateQuerier(*device.split("."))


### PR DESCRIPTION
I realized that at least `Redmi AirDots` sends `AT+XEVENT` with other data:
```AT+XEVENT=BATTERY,9```

instead of data your expect like this:
```AT+XEVENT=BATTERY,6,11,461,0```

Now the script no longer crashes and supports more headphones.