### PR TITLE
Add support for Nearby/FastPair protocol (Pixel buds left/right/case report)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -111,7 +111,7 @@ result = int(query)  # returns integer between 0 and 100
 # or
 result = str(query)  # returns "0%".."100%"
 # or
-result = query.query()  # returns a dictonary {'overall': 100}
+result = query.query()  # returns a dictonary, e.g. {'overall': 100, 'left': 100, 'right': 100, 'case': 87}
 ```
 
 As errors can occur in a wireless system, you probably want to handle them:

--- a/Readme.md
+++ b/Readme.md
@@ -110,6 +110,8 @@ query = BatteryStateQuerier("11:22:33:44:55:66", "4")
 result = int(query)  # returns integer between 0 and 100
 # or
 result = str(query)  # returns "0%".."100%"
+# or
+result = query.query()  # returns a dictonary {'overall': 100}
 ```
 
 As errors can occur in a wireless system, you probably want to handle them:

--- a/bluetooth_battery.py
+++ b/bluetooth_battery.py
@@ -83,7 +83,8 @@ class BatteryStateQuerier:
 
         The actual query can be performed using the int() and str() method.
         """
-        self._bt_settings = bluetooth_mac, int(bluetooth_port or RFCOMMSocket.find_rfcomm_port(bluetooth_mac))
+        self._bluetooth_mac = bluetooth_mac
+        self._bluetooth_port = int(bluetooth_port or RFCOMMSocket.find_rfcomm_port(bluetooth_mac))
 
     def __int__(self):
         """
@@ -108,8 +109,8 @@ class BatteryStateQuerier:
         """
         result: dict[str, int] = {}
         sock = RFCOMMSocket()
-        logger.debug("Connecting to {}.{}".format(self._bt_settings[0], self._bt_settings[1]))
-        sock.connect(self._bt_settings)
+        logger.debug("Connecting to {}.{}".format(self._bluetooth_mac, self._bluetooth_port))
+        sock.connect((self._bluetooth_mac, self._bluetooth_port))
         logger.debug("Connected")
         # Iterate received packets until there is no more or a result was found
         for line in sock:


### PR DESCRIPTION
This is, at least, what Google Pixel Buds use to report left, right, and case battery status. Also, extend the BatteryStateQuerier class to support returning more than one value, and I added `logging` support (mostly for my debugging convenience).

I figured that out by enabling BT snoop logs on my phone. The protocol is simple, and data is sent from the headset automatically on connection (and regularly when the battery level changes).  Once I figured out which UUID the channel/port corresponded to, I found out it is Google's Nearby/Fastpair protocol (https://developers.google.com/nearby/fast-pair/landing-page). The protocol documentation doesn't appear to be public, but information can be gathered from opensource code.

Only tested with Google Pixel Buds A-series. I believe some BT speakers use that protocol as well.